### PR TITLE
link to https://github.com/Bioconductor/BioC2022

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -104,7 +104,7 @@ paginate = 50
 [[menu.topbar]]
     weight = 1
     name = "GitHub"
-    url = "https://github.com/Bioconductor"
+    url = "https://github.com/Bioconductor/BioC2022"
     pre = "<i class='fab fa-2x fa-github'></i>"
 
 # [[menu.topbar]]


### PR DESCRIPTION
instead of https://github.com/Bioconductor