### PR TITLE
spell out the meaning of CAB

### DIFF
--- a/data/abstracts/day2_1000_Shorttalk.yaml
+++ b/data/abstracts/day2_1000_Shorttalk.yaml
@@ -1,4 +1,4 @@
-title: "Meet the CAB"
+title: "Meet the Community Advisory Board"
 paper: ""
 session_type: "Short talk"
 authors: ""

--- a/data/abstracts/day2_1000_meetCAB.yaml
+++ b/data/abstracts/day2_1000_meetCAB.yaml
@@ -1,4 +1,4 @@
-title: "Meet the CAB"
+title: "Meet the Community Advisory Board"
 paper: ""
 session_type: "Meet the CAB"
 authors: ""


### PR DESCRIPTION
Note:

- The CAB also would have liked to add a link on the 'Title/Event' field to the CAB web page of the Bioconductor website (http://bioconductor.org/about/community-advisory-board/) but I tried both markdown and HTML syntax and neither worked.

What I have tried:

```
[Community Advisory Board](http://bioconductor.org/about/community-advisory-board/) # markdown
<a href="http://bioconductor.org/about/community-advisory-board/">Community Advisory Board</a>
```

For homogeneity, this PR should be followed by another one to spell out the meaning of 'SAB' in "Meet the TAB/core"