### PR TITLE
fixing link of sponsors combined

### DIFF
--- a/data/clients/001.moderna.platinum.yaml
+++ b/data/clients/001.moderna.platinum.yaml
@@ -1,4 +1,8 @@
 name: "Moderna Therapeutics"
+name2: ""
 image: "/img/clients/logo_moderna.png"
+name2: ""
 url: "https://www.modernatx.com/"
+name2: ""
 level: "platinum"
+name2: ""

--- a/data/clients/002.nanostring.platinum.yaml
+++ b/data/clients/002.nanostring.platinum.yaml
@@ -1,4 +1,8 @@
 name: "NanoString Technologies"
+name2: ""
 image: "/img/clients/logo_nanostring.png"
+name2: ""
 url: "https://www.nanostring.com/"
+name2: ""
 level: "platinum"
+name2: ""

--- a/data/clients/003.microsoft.gold.yaml
+++ b/data/clients/003.microsoft.gold.yaml
@@ -1,4 +1,8 @@
 name: "Microsoft"
+name2: ""
 image: "/img/clients/logo_microsoft.png"
+name2: ""
 url: "https://www.microsoft.com/genomics/"
+name2: ""
 level: "gold"
+name2: ""

--- a/data/clients/004.sevenbridges.gold.yaml
+++ b/data/clients/004.sevenbridges.gold.yaml
@@ -1,4 +1,8 @@
 name: "Seven Bridges Genomics"
+name2: ""
 image: "/img/clients/logo_sevenbridges.png"
+name2: ""
 url: "https://www.sevenbridges.com/"
+name2: ""
 level: "gold"
+name2: ""

--- a/data/clients/005.tercen.silver.yaml
+++ b/data/clients/005.tercen.silver.yaml
@@ -1,4 +1,8 @@
 name: "Tercen Data Analytics Ltd."
+name2: ""
 image: "/img/clients/logo_tercen.png"
+name2: ""
 url: "https://www.tercen.com/"
+name2: ""
 level: "silver"
+name2: ""

--- a/data/clients/006.stickermule.other.yaml
+++ b/data/clients/006.stickermule.other.yaml
@@ -1,4 +1,8 @@
 name: "SickerMule"
+name2: ""
 image: "/img/clients/logo_stickermule.png"
+name2: ""
 url: "https://mule.to/p2oj"
+name2: ""
 level: "other"
+name2: ""

--- a/data/clients/007.rconsortium.silver.yaml
+++ b/data/clients/007.rconsortium.silver.yaml
@@ -1,4 +1,8 @@
 name: "R Consortium"
+name2: ""
 image: "/img/clients/logo_ronsortium.png"
+name2: ""
 url: "https://www.r-consortium.org/"
+name2: ""
 level: "silver"
+name2: ""

--- a/data/clients/008.maze.gold.yaml
+++ b/data/clients/008.maze.gold.yaml
@@ -1,4 +1,8 @@
 name: "Maze Therapeutics"
+name2: ""
 image: "/img/clients/logo_mace.png"
+name2: ""
 url: "https://mazetx.com/"
+name2: ""
 level: "gold"
+name2: ""

--- a/data/clients/009.bluebird.silver.yaml
+++ b/data/clients/009.bluebird.silver.yaml
@@ -1,4 +1,8 @@
 name: "bluebird bio"
+name2: ""
 image: "/img/clients/bluebird_logo.png"
+name2: ""
 url: "https://www.bluebirdbio.com/"
+name2: ""
 level: "silver"
+name2: ""

--- a/data/clients/010.genentechbiogen.gold.yaml
+++ b/data/clients/010.genentechbiogen.gold.yaml
@@ -1,4 +1,6 @@
-name: "Genentech-Biogen"
+name: "Genentech"
 image: "/img/clients/logo_genetech_biogen.png"
-url: "https://www.gene.com/, https://www.biogen.com/"
+url: "https://www.gene.com/"
 level: "gold"
+name2: "Biogen"
+url2: "https://www.biogen.com/"

--- a/layouts/shortcodes/sponsors.html
+++ b/layouts/shortcodes/sponsors.html
@@ -10,7 +10,7 @@
       <div class="panel panel-default">
         <div class="panel-body"> 
           <img src="{{.image}}" class="img-responsive center-block"> 
-          <a href = "{{.url}}"> {{.name}} </a>
+          <a href = "{{.url}}" target="_blank"> {{.name}} </a>
         </div>
       </div>
     </div>
@@ -31,7 +31,11 @@
       <div class="panel panel-default">
         <div class="panel-body"> 
           <img src="{{.image}}" class="img-responsive center-block"> 
-          <a href = "{{.url}}"> {{.name}} </a>
+          {{ if eq $sponsors.name2 "" }}
+          <a href="{{.url}}" target="_blank"> {{.name}} </a>
+          {{ else }}
+          <a href="{{.url}}" target="_blank"> {{.name}} </a> & <a href = "{{.url2}}" target="_blank"> {{.name2}} </a> 
+          {{ end }}
         </div>
       </div>
     </div>
@@ -53,7 +57,7 @@
       <div class="panel panel-default">
         <div class="panel-body"> 
           <img src="{{.image}}" class="img-responsive center-block"> 
-          <a href = "{{.url}}"> {{.name}} </a>
+          <a href = "{{.url}}" target="_blank"> {{.name}} </a> 
         </div>
       </div>
     </div>
@@ -74,7 +78,7 @@
       <div class="panel panel-default">
         <div class="panel-body"> 
           <img src="{{.image}}" class="img-responsive center-block"> 
-          <a href = "{{.url}}"> {{.name}} </a>
+          <a href = "{{.url}}" target="_blank"> {{.name}} </a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Adding a second name (name2) to the sponsors' YAML files helped to adapt the shortcode to include two sponsors under the gold category. Not ideal, but it works.